### PR TITLE
Make the template_matcher_node depend on generated messages.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ add_dependencies(icp_matcher_node ${catkin_EXPORTED_TARGETS} ${PCL_EXPORTED_TARG
 target_link_libraries(icp_matcher_node ${LINK_LIBS})
 
 add_executable(template_matcher_node src/template_matcher_node.cpp src/TemplateMatching.cpp)
-add_dependencies(template_matcher_node ${catkin_EXPORTED_TARGETS} ${PCL_EXPORTED_TARGETS})
+add_dependencies(template_matcher_node ${catkin_EXPORTED_TARGETS} ${PCL_EXPORTED_TARGETS} ${PROJECT_NAME}_generate_messages_cpp)
 target_link_libraries(template_matcher_node ${LINK_LIBS})
 
 add_executable(mesh_sampler_node tools/mesh_sampler_node.cpp)


### PR DESCRIPTION
Otherwise, on slow platforms (like armhf), the generation of
the messages can race with the build, causing the build to
sometimes fail.  We see this on the buildfarm, and this change
should fix that.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This should solve the build problems seen in http://build.ros.org/view/Mbin_ubhf_uBhf/job/Mbin_ubhf_uBhf__rail_mesh_icp__ubuntu_bionic_armhf__binary/59/console , for instance.  I'd appreciate a review, merge, and release into Melodic so that I can think about doing a sync soon.  Thanks in advance!