### PR TITLE
Replacement of hard coded path specification with absolute or reference path specification

### DIFF
--- a/include/rail_mesh_icp/TemplateMatching.h
+++ b/include/rail_mesh_icp/TemplateMatching.h
@@ -1,4 +1,3 @@
-#include <ros/package.h>
 #include <ros/time.h>
 #include <pcl/io/ply_io.h>
 #include <pcl_conversions/pcl_conversions.h>
@@ -13,9 +12,9 @@
 class TemplateMatcher {
     public:
         TemplateMatcher(ros::NodeHandle& nh, std::string& matching_frame, std::string& pcl_topic,
-                                 std::string& template_file, tf::Transform& initial_estimate,
-                                 tf::Transform& template_offset, std::string& template_frame, bool visualize,
-                                 bool debug, bool latch, bool pre_processed_cloud);
+                        std::string& template_file_path, tf::Transform& initial_estimate,
+                        tf::Transform& template_offset, std::string& template_frame, bool visualize,
+                        bool debug, bool latch, bool pre_processed_cloud);
 
         // handles requests to match a template CAD model (in PCD form) to a point cloud from a point cloud topic
         bool handle_match_template(rail_mesh_icp::TemplateMatch::Request& req, rail_mesh_icp::TemplateMatch::Response& res);

--- a/launch/mesh_sampler_demo.launch
+++ b/launch/mesh_sampler_demo.launch
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<launch>
+
+  <arg name="file_in" default="$(find rail_mesh_icp)/cad_models/corner.ply" />
+  <arg name="file_out" default="$(find rail_mesh_icp)/cad_models/corner.pcd" />
+  <arg name="n_samples" default="100000" />
+  <arg name="leaf_size" default="0.010000" />
+
+  <node pkg="rail_mesh_icp" type="mesh_sampler_node" name="mesh_sampler_demo" output="screen"
+        args="$(arg file_in) $(arg file_out) -n_samples $(arg n_samples) -leaf_size $(arg leaf_size) " />
+
+</launch>

--- a/launch/mesh_sampler_demo.launch
+++ b/launch/mesh_sampler_demo.launch
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<launch>
+
+  <arg name="mesh_file_path" default="$(find rail_mesh_icp)/cad_models" />
+  <arg name="file_in" default="$(arg mesh_file_path)/corner.ply" />
+  <arg name="file_out" default="$(arg mesh_file_path)/corner.pcd" />
+  <arg name="n_samples" default="100000" />
+  <arg name="leaf_size" default="0.010000" />
+
+  <node pkg="rail_mesh_icp" type="mesh_sampler_node" name="mesh_sampler_demo" output="screen"
+        args="$(arg file_in) $(arg file_out) -n_samples $(arg n_samples) -leaf_size $(arg leaf_size) " />
+
+</launch>

--- a/launch/template_match_demo.launch
+++ b/launch/template_match_demo.launch
@@ -9,7 +9,7 @@
     <!-- Template Matching Params -->
     <arg name="match_frame"             default="map"/>
     <arg name="cloud_topic"             default="/head_camera/depth_registered/points"/>
-    <arg name="template_filename"       default="corner.pcd"/>
+    <arg name="template_file_path"      default="$(find rail_mesh_icp)/cad_models/corner.pcd"/>
     <arg name="initial_estimate"        default="1.9 0.1 0.83 1.57 0 0"/>
     <arg name="template_offset"         default="0.144 0.118 0.148 0 0 -0.785"/>
     <arg name="output_frame"            default="template_pose"/>
@@ -18,7 +18,6 @@
     <arg name="latch_initial_estimate"  default="true"/>
     <arg name="provide_processed_cloud" default="false"/>
 
-
     <!-- gives static world tf of initial estimate for reference -->
     <node pkg="tf" type="static_transform_publisher" name="base_link_broadcaster" args="$(arg initial_estimate) map initial_estimate 10" />
 
@@ -26,7 +25,7 @@
     <node pkg="rail_mesh_icp" type="template_matcher_node" name="template_matcher_demo_node" output="screen">
         <param name="matching_frame"          value="$(arg match_frame)"/>
         <param name="pcl_topic"               value="$(arg cloud_topic)"/>
-        <param name="template_file"           value="$(arg template_filename)"/>
+        <param name="template_file_path"           value="$(arg template_file_path)"/>
         <param name="initial_estimate_string" value="$(arg initial_estimate)"/>
         <param name="template_offset_string"  value="$(arg template_offset)"/>
         <param name="template_frame"          value="$(arg output_frame)"/>

--- a/src/TemplateMatching.cpp
+++ b/src/TemplateMatching.cpp
@@ -1,7 +1,7 @@
 #include "rail_mesh_icp/TemplateMatching.h"
 
 TemplateMatcher::TemplateMatcher(ros::NodeHandle& nh, std::string& matching_frame, std::string& pcl_topic,
-                                 std::string& template_file, tf::Transform& initial_estimate,
+                                 std::string& template_file_path, tf::Transform& initial_estimate,
                                  tf::Transform& template_offset, std::string& template_frame, bool visualize,
                                  bool debug, bool latch, bool pre_processed_cloud) {
     matcher_nh_ = nh;
@@ -16,13 +16,9 @@ TemplateMatcher::TemplateMatcher(ros::NodeHandle& nh, std::string& matching_fram
     viz_ = visualize;
     ros::NodeHandle pnh("~");
 
-    // gets template pcd file
-    std::string templates_path = ros::package::getPath("rail_mesh_icp")+"/cad_models/";
-    std::string template_filepath = templates_path+template_file;
-
     // loads template cloud
     template_cloud_ = boost::make_shared<pcl::PointCloud<pcl::PointXYZRGB>>();
-    if (pcl::io::loadPCDFile<pcl::PointXYZRGB>(template_filepath,*template_cloud_) < 0) {
+    if (pcl::io::loadPCDFile<pcl::PointXYZRGB>(template_file_path, *template_cloud_) < 0) {
         ROS_ERROR("Could not load template PCD.");
         exit(-1);
     }

--- a/src/template_matcher_node.cpp
+++ b/src/template_matcher_node.cpp
@@ -1,4 +1,5 @@
 #include <ros/ros.h>
+#include <ros/package.h>
 
 #include "rail_mesh_icp/TemplateMatching.h"
 
@@ -9,7 +10,6 @@ int main(int argc, char** argv){
     // sets the default params
     std::string matching_frame = "map";
     std::string pcl_topic = "/head_camera/depth_registered/points";
-    std::string template_file = "corner.pcd";
     std::string initial_estimate_string = "0 0 0 0 0 0";
     std::string template_offset_string = "0 0 0 0 0 0";
     std::string template_frame = "template_pose";
@@ -18,10 +18,12 @@ int main(int argc, char** argv){
     bool latched = true;
     bool pre_processed_cloud = false;
 
+    std::string template_file_path = ros::package::getPath("rail_mesh_icp") + "/cad_models/" + "corner.pcd";
+
     // gets roslaunch params
     pnh.getParam("matching_frame", matching_frame);
     pnh.getParam("pcl_topic", pcl_topic);
-    pnh.getParam("template_file", template_file);
+    pnh.getParam("template_file_path", template_file_path);
     pnh.getParam("initial_estimate_string", initial_estimate_string);
     pnh.getParam("template_offset_string", template_offset_string);
     pnh.getParam("template_frame", template_frame);
@@ -51,7 +53,7 @@ int main(int argc, char** argv){
     template_offset.setRotation(tf::Quaternion(offset[4],offset[5],offset[3]));
 
     // starts a template matcher
-    TemplateMatcher matcher(nh,matching_frame,pcl_topic,template_file,initial_estimate,template_offset,template_frame,
+    TemplateMatcher matcher(nh,matching_frame,pcl_topic,template_file_path,initial_estimate,template_offset,template_frame,
                             visualize,debug,latched,pre_processed_cloud);
 
     try{

--- a/tools/mesh_sampler_node.cpp
+++ b/tools/mesh_sampler_node.cpp
@@ -13,8 +13,6 @@
 #include <pcl/console/print.h>
 #include <pcl/console/parse.h>
 
-#include <ros/package.h>
-
 inline double
 uniform_deviate (int seed)
 {
@@ -130,8 +128,6 @@ main (int argc, char **argv)
   ros::NodeHandle matcher_nh;
   print_info ("Convert a CAD model to a point cloud using uniform sampling.\n");
 
-  std::string package_path = ros::package::getPath("rail_mesh_icp");
-
   if (argc < 3) {
     printHelp (argc, argv);
     return (-1);
@@ -160,7 +156,7 @@ main (int argc, char **argv)
   // reads the PLY file
   vtkSmartPointer<vtkPolyData> polydata1 = vtkSmartPointer<vtkPolyData>::New ();
   pcl::PolygonMesh mesh;
-  pcl::io::loadPolygonFilePLY (package_path+"/cad_models/"+argv[ply_file_indices[0]], mesh);
+  pcl::io::loadPolygonFilePLY (argv[ply_file_indices[0]], mesh);
   pcl::io::mesh2vtk (mesh, polydata1);
 
   //make sure that the polygons are triangles!
@@ -187,5 +183,5 @@ main (int argc, char **argv)
   pcl::PointCloud<pcl::PointXYZ>::Ptr cloud_xyz (new pcl::PointCloud<pcl::PointXYZ>);
   // Strip uninitialized normals and colors from cloud:
   pcl::copyPointCloud (*voxel_cloud, *cloud_xyz);
-  savePCDFileASCII (package_path+"/cad_models/"+argv[pcd_file_indices[0]], *cloud_xyz);
+  savePCDFileASCII (argv[pcd_file_indices[0]], *cloud_xyz);
 }


### PR DESCRIPTION
Changed specification of arguments. 

Instead of loading input and output files from the hard coded path to rail_mesh_icp/cad_models directory, files can be loaded with any absolute or reference path. Its sample is summarized in mesh_sampler_demo.launch file.